### PR TITLE
Adding attributes specification support on simple queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ The package can be installed from [Hex](https://hex.pm/packages/arangoex):
       [applications: [:arangoex]]
     end
     ```
+
+## Running Tests
+
+You can run tests with `mix test`, but you must startup an instance of
+arangodb without authentication. Using
+the [official docker image](https://hub.docker.com/_/arangodb/) is
+recommended.

--- a/lib/arangoex/document.ex
+++ b/lib/arangoex/document.ex
@@ -6,6 +6,9 @@ defmodule Arangoex.Document do
 
   use Arangoex, base_url: ["/", "_api", "/", "document"]
 
+  defdelegate list(collection, attrs \\ [], opts \\ []), to: Simple, as: :list_documents
+  defdelegate list_keys(collection, type \\ "path", opts \\ []), to: Simple, as: :list_keys
+
   # POST /_api/document/{collection}
   # Create a new document.
   def create(collection, document, opts \\ []) do
@@ -33,15 +36,6 @@ defmodule Arangoex.Document do
     document_handle
       |> build_url(opts)
       |> Arangoex.head(opts)
-  end
-
-  # proxy to PUT /_api/simple/all
-  def list(collection, opts \\ []), do: Simple.list_documents(collection, opts)
-
-  # proxy to PUT /_api/simple/all-keys
-  # todo - refactor to make type an option parameter
-  def list_keys(collection, type \\ "path", opts \\ []) do
-    Simple.list_keys(collection, type, opts)
   end
 
   # PUT /_api/document/{document-handle}

--- a/lib/arangoex/simple.ex
+++ b/lib/arangoex/simple.ex
@@ -1,28 +1,76 @@
 defmodule Arangoex.Simple do
-  @moduledoc false
+  @moduledoc """
+  ArangoDB HTTP Interface for Simple Queries
 
-  alias Arangoex.JSON
+  ## TODO
+
+  * Implement function for `PUT /_api/simple/within-rectangle`
+  * Specify typespecs
+
+  """
 
   use Arangoex, base_url: ["/", "_api", "/", "simple"]
+  alias Arangoex.{JSON,Response}
 
-  # todo or not (deprecated):
-  # PUT /_api/simple/fulltext
-  # PUT /_api/simple/near
-  # PUT /_api/simple/range
-  # PUT /_api/simple/within
-  # PUT /_api/simple/within-rectangle
+  @doc """
+  Returns the first document in the collection identified by
+  `collection_name` that matches the example document.
 
-  # PUT /_api/simple/first-example
-  # Return the first document in the collection identified by colleciton-name that matches the example document.
+  The HTTP requests looks like:
+
+      PUT /_api/simple/first-example
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `example` - a map representing an example for the query to use
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.get_first_document_by_example("exotic_cars", %{brand: "lamborghini"})
+
+  """
+  @spec get_first_document_by_example(binary, map, keyword) :: {:ok, Response.t}
   def get_first_document_by_example(collection_name, example, opts \\ []) do
     {:ok, body} = JSON.encode(%{collection: collection_name, example: example})
 
     "first-example"
-      |> build_url(opts) |> Arangoex.put(body, opts)
+    |> build_url(opts)
+    |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/any
-  # Return a random document from the collection identified by collection-name.
+  @doc """
+  Return a random document from the collection identified by `collection_name`.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/any
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.get_random_document("exotic_cars")
+
+  """
   def get_random_document(collection_name, opts \\ []) do
     {:ok, body} = JSON.encode(%{collection: collection_name})
 
@@ -31,30 +79,115 @@ defmodule Arangoex.Simple do
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/all
-  # Returns all documents in a collection.
-  def list_documents(collection_name, opts \\ []) do
-    # todo - implement skip, limit and batchsize? options
-    {:ok, body} = JSON.encode(%{collection: collection_name})
+  @doc """
+  Returns all documents in a collection.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/all
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `attrs` - a keyword list of attributes specific to this type of query
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Attributes (optional)
+
+  * `skip` - the number of documents to skip in the query
+  * `limit` - the maximum number of documents to return in the query
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.list_documents("exotic_cars")
+
+  """
+  def list_documents(collection_name, attrs \\ [], opts \\ []) do
+    {:ok, body} = attrs
+      |> Enum.into(%{collection: collection_name})
+      |> JSON.encode
 
     "all"
       |> build_url(opts)
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/by-example
-  # Return all documents in the collection identified by colleciton-name that match the example document.
-  def list_documents_by_example(collection_name, example, opts \\ []) do
-    # todo - implement skip and limit options
-    {:ok, body} = JSON.encode(%{collection: collection_name, example: example})
+  @doc """
+  Return all documents in the collection identified by `collection_name`
+  that match the example document.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/by-example
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `example` - a map representing the structure of an example document
+  * `attrs` - a keyword list of attributes specific to this type of query
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Attributes (optional)
+
+  * `skip` - the number of documents to skip in the query
+  * `limit` - the maximum number of documents to return in the query
+  * `batchSize` - the maximum number of results returned in single query
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.list_documents_by_example("exotic_cars", %{continent: "european"})
+
+  """
+  def list_documents_by_example(collection_name, example, attrs \\ [], opts \\ []) do
+    {:ok, body} = attrs
+      |> Enum.into(%{collection: collection_name, example: example})
+      |> JSON.encode
 
     "by-example"
       |> build_url(opts)
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/lookup-by-keys
-  # Return all documents in the collection identified by collection-name for the given keys.
+  @doc """
+  Return all documents in the collection identified by `collection_name`
+  for the given keys.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/lookup-by-keys
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `keys` - a list of keys of documents to retrieve
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.list_documents_for_keys("exotic_cars", ["car1", "car2"]})
+
+  """
   def list_documents_for_keys(collection_name, keys \\ [], opts \\ []) do
     {:ok, body} = JSON.encode(%{collection: collection_name, keys: keys})
 
@@ -63,9 +196,37 @@ defmodule Arangoex.Simple do
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/all-keys
-  # Returns a list of keys/ids/paths for documents in a collection.
-  # todo - refactor to make type an option parameter
+  @doc """
+  Returns a list of keys/ids/paths for documents in a collection.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/all-keys
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `type` - a string representing the type of result (defaults to `path`)
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Supported Types
+
+  * `id` - returns a list of document ids (`_id` attributes)
+  * `key` - returns a list of document keys (`_key` attributes)
+  * `path` - returns a list of document URI paths (`_path` attributes)
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.list_keys("exotic_cars", "key")
+
+  """
   def list_keys(collection, type \\ "path", opts \\ []) do
     {:ok, body} = JSON.encode(%{collection: collection, type: type})
 
@@ -74,44 +235,182 @@ defmodule Arangoex.Simple do
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/remove-by-example
-  # Remove documents in the collection identified by collection-name that match the example document.
-  def remove_documents_by_example(collection_name, example, opts \\ []) do
-    # todo - implement limit and waitForSync options
-    {:ok, body} = JSON.encode(%{collection: collection_name, example: example})
+  @doc """
+  Remove documents in the collection identified by `collection_name`
+  that match the example document.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/remove-by-example
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `example` - a document to compare documents against for matching
+  * `attrs` - a keyword list of attributes specific to this type of query
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Attributes
+
+  * `limit` - the maximum number of documents to delete in the query
+  * `waitForSync` - if `true`, remove operations will be instantly
+    synced to disk, otherwise normal sync behavior will occur
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.remove_documents_by_example("movies", %{category: "comedy"}])
+
+  """
+  def remove_documents_by_example(collection_name, example, attrs \\ [], opts \\ []) do
+    {:ok, body} = attrs
+      |> Enum.into(%{collection: collection_name, example: example})
+      |> JSON.encode
 
     "remove-by-example"
       |> build_url(opts)
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/remove-by-keys
-  # Remove all documents in the collection identified by collection-name for the given keys.
-  def remove_documents_for_keys(collection_name, keys \\ [], opts \\ []) do
-    # todo - implement returnOld, silent, and waitForSync options
-    {:ok, body} = JSON.encode(%{collection: collection_name, keys: keys})
+  @doc """
+  Remove all documents in the collection identified by `collection_name`
+  for the given keys.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/remove-by-keys
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `keys` - a list of the `_keys` of documents to remove
+  * `attrs` - a keyword list of attributes specific to this type of query
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Attributes
+
+  * `returnOld` - if `true` and `silent` is `false`, then it returns
+    the complete documents that were removed
+  * `silent` - if `false`, then returns list with removed documents
+    (default: returns `_id`, `_key`, `_rev`)
+  * `waitForSync` - if `true`, remove operations will be instantly
+    synced to disk, otherwise normal sync behavior will occur
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.remove_documents_for_keys("movies", ["movie1", "movie2"])
+
+  """
+  def remove_documents_for_keys(collection_name, keys \\ [], attrs \\ [], opts \\ []) do
+    {:ok, body} = attrs
+      |> Enum.into(%{collection: collection_name, keys: keys})
+      |> JSON.encode
 
     "remove-by-keys"
       |> build_url(opts)
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/replace-by-example
-  # Replace all documents in the collection identified by collection-name that match the example document.
-  def replace_documents_by_example(collection_name, example, document, opts \\ []) do
-    # todo - implement limit and waitForSync options
-    {:ok, body} = JSON.encode(%{collection: collection_name, example: example, newValue: document})
+  @doc """
+  Replace all documents in the collection identified by
+  `collection_name` that match the example document.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/replace-by-example
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `example` - a document to compare documents against for matching
+  * `document` - a document to replace the matched documents with
+  * `attrs` - a keyword list of attributes specific to this type of query
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Attributes
+
+  * `limit` - the maximum number of documents to delete in the query
+  * `waitForSync` - if `true`, remove operations will be instantly
+    synced to disk, otherwise normal sync behavior will occur
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.replace_documents_by_example("soda-inventory", %{brand: "coke"}, %{brand: "pepsi"})
+
+  """
+  def replace_documents_by_example(collection_name, example, document, attrs \\ [], opts \\ []) do
+    {:ok, body} = attrs
+      |> Enum.into(%{collection: collection_name, example: example, newValue: document})
+      |> JSON.encode
 
     "replace-by-example"
       |> build_url(opts)
       |> Arangoex.put(body, opts)
   end
 
-  # PUT /_api/simple/update-by-example
-  # Update all documents in the collection identified by collection-name that match the example document.
-  def update_documents_by_example(collection_name, example, document, opts \\ []) do
-    # todo - implement keepNull, mergeObjects, limit, and waitForSync options
-    {:ok, body} = JSON.encode(%{collection: collection_name, example: example, newValue: document})
+  @doc """
+  Update all documents in the collection identified by
+  `collection_name` that match the example document.
+
+  The HTTP requests looks like:
+
+      PUT /_api/simple/update-by-example
+
+  ## Arguments
+
+  * `collection_name` - a string representing the collection name
+  * `example` - a document to compare documents against for matching
+  * `document` - a document to update/patch the matched documents with
+  * `attrs` - a keyword list of attributes specific to this type of query
+  * `opts` - a keyword list of options on how to make the query
+
+  ## Attributes
+
+  * `keepNull` - if `false`, all attributes in data with null values
+    will be removed from updated document.
+  * `mergeObjects` - if `false`, the value in the patch document will
+    overwrite the existing value, otherwise, objects will be
+    merged. (default: true)
+  * `limit` - the maximum number of documents to delete in the query
+  * `waitForSync` - if `true`, remove operations will be instantly
+    synced to disk, otherwise normal sync behavior will occur
+
+  ## Options
+
+  * `query_params` - a keyword list of query params to build into the
+    request url
+  * `headers` - a list of 2-length tuples for HTTP headers
+    (e.g. [{"Connection", "close"}] used in request
+
+  ## Example
+
+      iex> Arangoex.Simple.update_documents_by_example("soda-inventory", %{brand: "coke"}, %{brand: "pepsi"})
+
+  """
+  def update_documents_by_example(collection_name, example, document, attrs \\ [], opts \\ []) do
+    {:ok, body} = attrs
+      |> Enum.into(%{collection: collection_name, example: example, newValue: document})
+      |> JSON.encode
 
     "update-by-example"
       |> build_url(opts)

--- a/test/arangoex/simple_test.exs
+++ b/test/arangoex/simple_test.exs
@@ -1,0 +1,154 @@
+defmodule Arangoex.SimpleTest do
+  use ExUnit.Case, async: false
+
+  alias Arangoex.{
+    Collection,
+    Document,
+    JSON,
+    Simple
+  }
+
+  @collection_name "cars"
+
+  @document1 %{brand: "Ford", model: "Festiva"}
+  @document2 %{brand: "Toyota", model: "Camry"}
+
+  @example %{brand: "Ford"}
+
+  setup do
+    Collection.create(%{name: @collection_name})
+
+    {:ok, response1} = Document.create(@collection_name, @document1)
+    {:ok, response2} = Document.create(@collection_name, @document2)
+
+    on_exit fn ->
+      Collection.remove(@collection_name)
+    end
+
+    {:ok, responses: [response1, response2]}
+  end
+
+  test "get_first_document_by_example() gets first document by example from a collection" do
+    {:ok, response} = Simple.get_first_document_by_example(@collection_name, @example)
+
+    body = JSON.decode!(response.body)
+
+    assert get_in(body, ["code"]) == 200
+    assert get_in(body, ["document", "brand"]) == "Ford"
+    assert get_in(body, ["document", "model"]) == "Festiva"
+  end
+
+  test "get_random_document() gets a random document from a collection" do
+    {:ok, response} = Simple.get_random_document(@collection_name)
+
+    body = JSON.decode!(response.body)
+    doc  = get_in(body, ["document"])
+
+    assert get_in(body, ["code"]) == 200
+    assert Map.has_key?(doc, "brand")
+    assert Map.has_key?(doc, "model")
+  end
+
+  @example_brands ["Ford", "Toyota"]
+  @example_models ["Festiva", "Camry"]
+  test "list_documents() gets all documents in a collection" do
+    {:ok, response} = Simple.list_documents(@collection_name)
+
+    body = JSON.decode!(response.body)
+
+    [document1, document2] = get_in(body, ["result"])
+
+    assert Enum.member?(@example_brands, get_in(document1, ["brand"]))
+    assert Enum.member?(@example_models, get_in(document1, ["model"]))
+
+    assert Enum.member?(@example_brands, get_in(document2, ["brand"]))
+    assert Enum.member?(@example_models, get_in(document2, ["model"]))
+  end
+
+  test "list_documents_by_example() gets all documents matched by example document" do
+    {:ok, response} = Simple.list_documents_by_example(@collection_name, @example)
+
+    body = JSON.decode!(response.body)
+    [document] = get_in(body, ["result"])
+
+    assert get_in(document, ["brand"]) == "Ford"
+    assert get_in(document, ["model"]) == "Festiva"
+  end
+
+  test "list_documents_for_keys() gets all documents matched by example document", %{responses: [resp1|_]} do
+    key = JSON.decode!(resp1.body) |> get_in(["_key"])
+
+    {:ok, response} = Simple.list_documents_for_keys(@collection_name, [key])
+
+    body = JSON.decode!(response.body)
+    [document] = get_in(body, ["documents"])
+
+    assert get_in(document, ["brand"]) == "Ford"
+    assert get_in(document, ["model"]) == "Festiva"
+  end
+
+  test "list_keys() gets all keys for documents in collection" do
+    {:ok, response} = Simple.list_keys(@collection_name, "key")
+
+    body = JSON.decode!(response.body)
+    keys = get_in(body, ["result"])
+
+    assert Enum.count(keys) == 2
+  end
+
+  test "remove_documents_by_example() removes all documents matched by example document" do
+    {:ok, _} = Simple.remove_documents_by_example(@collection_name, @example)
+    {:ok, response} = Simple.list_documents(@collection_name)
+
+    body = JSON.decode!(response.body)
+    [result] = get_in(body, ["result"])
+
+    assert get_in(result, ["brand"]) == "Toyota"
+  end
+
+  test "remove_documents_for_keys() remove all documents match by list of keys", %{responses: responses} do
+    keys = Enum.map(responses, fn resp -> JSON.decode!(resp.body) |> get_in(["_key"]) end)
+    {:ok, _} = Simple.remove_documents_for_keys(@collection_name, keys)
+    {:ok, response} = Simple.list_documents(@collection_name)
+
+    assert [] == JSON.decode!(response.body) |> get_in(["result"])
+  end
+
+  @replaced_brands ["Chevrolet", "Toyota"]
+  @replaced_models ["Camaro", "Camry"]
+  test "replace_documents_by_example() replaces all documents matched by example by another document" do
+    replacement = %{brand: "Chevrolet", model: "Camaro"}
+
+    {:ok, _} = Simple.replace_documents_by_example(@collection_name, @example, replacement)
+    {:ok, response} = Simple.list_documents(@collection_name)
+
+    body = JSON.decode!(response.body)
+
+    [document1, document2] = get_in(body, ["result"])
+
+    assert Enum.member?(@replaced_brands, get_in(document1, ["brand"]))
+    assert Enum.member?(@replaced_models, get_in(document1, ["model"]))
+
+    assert Enum.member?(@replaced_brands, get_in(document2, ["brand"]))
+    assert Enum.member?(@replaced_models, get_in(document2, ["model"]))
+  end
+
+  @modified_brands ["Ford", "Toyota"]
+  @modified_models ["Ranger", "Camry"]
+  test "update_documents_by_example() updates all documents matched by example with another document" do
+    modification = %{model: "Ranger"}
+
+    {:ok, _} = Simple.update_documents_by_example(@collection_name, @example, modification)
+    {:ok, response} = Simple.list_documents(@collection_name)
+
+    body = JSON.decode!(response.body)
+
+    [document1, document2] = get_in(body, ["result"])
+
+    assert Enum.member?(@modified_brands, get_in(document1, ["brand"]))
+    assert Enum.member?(@modified_models, get_in(document1, ["model"]))
+
+    assert Enum.member?(@modified_brands, get_in(document2, ["brand"]))
+    assert Enum.member?(@modified_models, get_in(document2, ["model"]))
+  end
+end


### PR DESCRIPTION
# Summary

Adds support for specific attributes on Simple Queries through the `Arangoex.Simple` module.

## Example

I should now be able to specify things like `skip` and `limit` on queries that support such without mixing them into `opts`:

```elixir
Arangoex.Simple.list_documents("cars", limit: 100, skip: 50)
```

## Details

This slightly changes the optional parameter API used on `Arangoex.Simple` so that most of the functions in that module now take an arglist that looks like:

```elixir
def fun(collection_name, attrs \\ [], opts \\ [])
```
* `attrs` is intended for database query options
* `opts` is intended for specifying options for the HTTP layer.

I gathered that this was the intention after studying how `opts` was used by the rest of the library.  I think keeping them separate is good idea so that those layers of control-http and querying specification-don't get muddled together.

## Tests and Documentation

Each test is specified for happy-path testing and could be further refined if need be. Documentation has been written describing the API specified by ArangoDB 3.1.

## Updates

#### 2017-03-22 (MST)

* Updated `Document.list` to comply with new `attrs` arg list
* Changed `Document.list` and `Document.list_keys` to use `defdelegate`